### PR TITLE
Consistent index

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -246,7 +246,7 @@
   [& opts]
   (locking core
     (let [current-index (:index @core)
-          ; Create a new index, later we'll decide whether it needs to be added
+          ; Create a new index. Later we'll decide whether it needs to be added
           ; to the current core, next core, or both.
           ; Note that we need to wrap the *current* core's pubsub; the next
           ; core's pubsub module will be discarded in favor of the current one

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -253,12 +253,10 @@
           ; when core transition takes place.
           new-index (-> (apply riemann.index/index opts)
                         (core/wrap-index (:pubsub @core)))
-
           ; If the new index is equivalent to the old one, preserve the old one.
           chosen-index (if (service/equiv? current-index new-index)
                          current-index
                          new-index)]
-
       ; If the current core has no index, add the newly created one.
       (when (nil? current-index) (swap! core assoc :index chosen-index))
       ; Always add the chosen index to the next core, ready for core transition.

--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -231,12 +231,12 @@
            (reduce conj (:streams @next-core) things))))
 
 (defn index
-  "Create a new index and add it to the core and next core as needed.
+  "Create a new index and add it to the current core and next core as needed.
 
   If the current core has no index, add the new index to it.
 
-  If the next core has no index, add the current core's index (when equivalent)
-  or add the new index (when not equivalent).
+  To the next core, add the current core's index (when equivalent) or add the
+  new index (when not equivalent).
 
   In practice, because Riemann currently has only one index type (NBHM), only a
   single index will ever be created. It will be preserved across all future

--- a/test/riemann/config_test.clj
+++ b/test/riemann/config_test.clj
@@ -130,10 +130,12 @@
 (deftest index-test
   (let [i (index)]
     (testing "index creation helper creates the index properly"
-      (is (satisfies? Index i))
-      (is (= i (:index @next-core)))
-      (is (nil? (:index @core))))
-    (testing "index is applied to the core properly during initial load"
+      (is (satisfies? Index i)))
+    (testing "index creation helper sets the index of the current core"
+      (is (= i (:index @core))))
+    (testing "index creation helper sets the index of the next core"
+      (is (= i (:index @next-core))))
+    (testing "current core index is preserved after apply"
       (apply!)
       (is (identical? i (:index @core))))
     (testing "we have the proper reference to the index after a reload"


### PR DESCRIPTION
Fix the "orphaned indicies" problem described in riemann/riemann#957.

Allows a Riemann config to make multiple calls to riemann.config/index
with predictable results, both on initial load and after a reload.

Without this change, multiple calls are OK after reload or explicit
apply, but create orphan indices on initial load.